### PR TITLE
feat(tenant): implement multi-tenant resolver middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
+        "@types/express": "^5.0.6",
         "@types/jest": "^29.0.0",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.0.0",
@@ -2269,6 +2270,27 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -2298,6 +2320,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2307,6 +2354,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2387,6 +2441,41 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
+    "@types/express": "^5.0.6",
     "@types/jest": "^29.0.0",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
 import { HealthController } from "@infra/http/controllers/health.controller";
 import { CompaniesController } from "@infra/http/controllers/companies.controller";
 import { AuthController } from "@infra/http/controllers/auth.controller";
@@ -9,6 +9,7 @@ import { PrismaMagicTokenRepository } from "@infra/db/prisma.magic-token.reposit
 import { CreateCompanyUseCase } from "@use-cases/companies/create-company/create-company.usecase";
 import { RequestMagicLinkUseCase } from "@use-cases/auth/request-magic-link";
 import { VerifyMagicLinkUseCase } from "@use-cases/auth/verify-magic-link";
+import { TenantResolverMiddleware } from "@infra/http/middlewares/tenant-resolver.middleware";
 
 @Module({
   imports: [],
@@ -46,4 +47,10 @@ import { VerifyMagicLinkUseCase } from "@use-cases/auth/verify-magic-link";
     PrismaMagicTokenRepository,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    // Apply middleware only to protected routes (companies)
+    // This avoids conflicts with Swagger and auth routes
+    consumer.apply(TenantResolverMiddleware).forRoutes(CompaniesController);
+  }
+}

--- a/src/infra/http/controllers/companies.controller.ts
+++ b/src/infra/http/controllers/companies.controller.ts
@@ -7,7 +7,13 @@ import {
   HttpCode,
   HttpStatus,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from "@nestjs/swagger";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from "@nestjs/swagger";
 import { CreateCompanyDto } from "../dto/create-company.dto";
 import { CreateCompanyUseCase } from "../../../use-cases/companies/create-company/create-company.usecase";
 import { PrismaCompanyRepository } from "../../db/prisma.company.repository";
@@ -15,6 +21,7 @@ import { NotFoundError } from "../../../shared/errors";
 import { CompanyResponseDto } from "../dto/company-response.dto";
 
 @ApiTags("Companies")
+@ApiBearerAuth()
 @Controller("companies")
 export class CompaniesController {
   constructor(

--- a/src/infra/http/middlewares/tenant-resolver.middleware.spec.ts
+++ b/src/infra/http/middlewares/tenant-resolver.middleware.spec.ts
@@ -1,0 +1,170 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { Request, Response, NextFunction } from "express";
+import { TenantResolverMiddleware } from "./tenant-resolver.middleware";
+import { JwtService } from "@shared/utils/jwt.service";
+
+jest.mock("@shared/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("TenantResolverMiddleware", () => {
+  let middleware: TenantResolverMiddleware;
+  let mockRequest: any;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    middleware = new TenantResolverMiddleware();
+    mockRequest = {
+      headers: {},
+      path: "/companies",
+      method: "GET",
+    };
+    mockResponse = {};
+    nextFunction = jest.fn();
+  });
+
+  // Note: Public route exclusion is handled by NestJS .forRoutes(CompaniesController) in app.module.ts
+  // The middleware itself no longer handles route exclusion logic
+  // It is only applied to CompaniesController routes
+
+  describe("Protected routes", () => {
+    it("should throw UnauthorizedException when no token is provided", () => {
+      mockRequest.path = "/companies";
+
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow("Token não fornecido");
+    });
+
+    it("should throw UnauthorizedException when token is invalid", () => {
+      mockRequest.headers = {
+        authorization: "Bearer invalid-token",
+      };
+
+      jest.spyOn(JwtService, "verify").mockImplementation(() => {
+        throw new Error("Invalid token");
+      });
+
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow("Token inválido ou expirado");
+    });
+
+    it("should throw UnauthorizedException when companyId is missing from token", () => {
+      mockRequest.headers = {
+        authorization: "Bearer valid-token",
+      };
+
+      jest.spyOn(JwtService, "verify").mockReturnValue({
+        userId: "user-123",
+        email: "user@example.com",
+        companyId: "", // Empty companyId
+        role: "OWNER",
+      });
+
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow("Token inválido: companyId não encontrado");
+    });
+
+    it("should inject tenantId when valid token is provided", () => {
+      mockRequest.headers = {
+        authorization: "Bearer valid-token",
+      };
+
+      const mockPayload = {
+        userId: "user-123",
+        email: "user@example.com",
+        companyId: "company-456",
+        role: "OWNER",
+      };
+
+      jest.spyOn(JwtService, "verify").mockReturnValue(mockPayload);
+
+      middleware.use(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(mockRequest.tenantId).toBe("company-456");
+      expect(mockRequest.user).toEqual(mockPayload);
+      expect(nextFunction).toHaveBeenCalledWith();
+    });
+
+    it("should extract Bearer token correctly", () => {
+      mockRequest.headers = {
+        authorization: "Bearer my-jwt-token",
+      };
+
+      const mockPayload = {
+        userId: "user-123",
+        email: "user@example.com",
+        companyId: "company-456",
+        role: "ADMIN",
+      };
+
+      jest.spyOn(JwtService, "verify").mockReturnValue(mockPayload);
+
+      middleware.use(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(JwtService.verify).toHaveBeenCalledWith("my-jwt-token");
+      expect(mockRequest.tenantId).toBe("company-456");
+    });
+
+    it("should not extract token with invalid auth type", () => {
+      mockRequest.headers = {
+        authorization: "Basic base64-encoded-credentials",
+      };
+
+      expect(() => {
+        middleware.use(
+          mockRequest as Request,
+          mockResponse as Response,
+          nextFunction
+        );
+      }).toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/src/infra/http/middlewares/tenant-resolver.middleware.ts
+++ b/src/infra/http/middlewares/tenant-resolver.middleware.ts
@@ -1,0 +1,94 @@
+import {
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Request, Response, NextFunction } from "express";
+import { JwtService } from "@shared/utils/jwt.service";
+import { logger } from "@shared/logger";
+
+// Extend Express Request to include tenantId
+declare global {
+  namespace Express {
+    interface Request {
+      tenantId?: string;
+      user?: {
+        userId: string;
+        email: string;
+        companyId: string;
+        role: string;
+      };
+    }
+  }
+}
+
+@Injectable()
+export class TenantResolverMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const path = req.path || req.url || "";
+
+    try {
+      const token = this.extractTokenFromHeader(req);
+
+      if (!token) {
+        throw new UnauthorizedException("Token não fornecido");
+      }
+
+      const payload = JwtService.verify(token);
+
+      if (!payload.companyId) {
+        throw new UnauthorizedException(
+          "Token inválido: companyId não encontrado"
+        );
+      }
+
+      // Inject tenant context into request
+      req.tenantId = payload.companyId;
+      req.user = {
+        userId: payload.userId,
+        email: payload.email,
+        companyId: payload.companyId,
+        role: payload.role,
+      };
+
+      // Log tenant context
+      logger.info(
+        {
+          tenantId: req.tenantId,
+          userId: payload.userId,
+          path: path,
+          method: req.method,
+        },
+        "Tenant context resolved"
+      );
+
+      next();
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+
+      logger.error(
+        {
+          error: error instanceof Error ? error.message : "Unknown error",
+          path: path,
+        },
+        "Failed to resolve tenant context"
+      );
+
+      throw new UnauthorizedException("Token inválido ou expirado");
+    }
+  }
+
+  private extractTokenFromHeader(request: Request): string | undefined {
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+      return undefined;
+    }
+
+    const [type, token] = authHeader.split(" ");
+
+    return type === "Bearer" ? token : undefined;
+  }
+}


### PR DESCRIPTION
## Summary
Implementa **TENANT-01**: Middleware para Resolução de Tenant

## Changes
- ✅ **`TenantResolverMiddleware`** extrai `companyId` do JWT
- ✅ Injeta `tenantId` e `user` no request para uso downstream
- ✅ Aplicado apenas em `CompaniesController` (isolamento de escopo)
- ✅ **`@ApiBearerAuth()`** adicionado ao `CompaniesController` para Swagger
- ✅ Instalado `@types/express` para suporte de tipos
- ✅ Testes unitários do middleware (6 testes passando)

## Technical Details
- Middleware valida JWT e extrai payload
- Lança `UnauthorizedException` se token estiver ausente ou inválido
- Logs de resolução de contexto de tenant para observabilidade
- Aplicado via `.forRoutes(CompaniesController)` para escopo explícito

## Test Plan
- [x] Lint passing ✅
- [x] Build passing ✅
- [x] Tests passing (12/12) ✅
- [x] Manual test via Swagger com JWT válido ✅

Closes #41